### PR TITLE
Updated karma script to be nicer about trailing whitespace.

### DIFF
--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -100,7 +100,7 @@ module.exports = (robot) ->
     else
       msg.send msg.random karma.selfDeniedResponses(msg.message.user.name)
 
-  robot.respond /karma empty ?(\S+[^-\s])$/i, (msg) ->
+  robot.respond /karma empty ?(\S+[^-\s])\s*$/i, (msg) ->
     subject = msg.match[1].toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.kill subject
@@ -108,19 +108,19 @@ module.exports = (robot) ->
     else
       msg.send msg.random karma.selfDeniedResponses(msg.message.user.name)
 
-  robot.respond /karma( best)?$/i, (msg) ->
+  robot.respond /karma( best)?\s*$/i, (msg) ->
     verbiage = ["The Best"]
     for item, rank in karma.top()
       verbiage.push "#{rank + 1}. #{item.name} - #{item.karma}"
     msg.send verbiage.join("\n")
 
-  robot.respond /karma worst$/i, (msg) ->
+  robot.respond /karma worst\s*$/i, (msg) ->
     verbiage = ["The Worst"]
     for item, rank in karma.bottom()
       verbiage.push "#{rank + 1}. #{item.name} - #{item.karma}"
     msg.send verbiage.join("\n")
 
-  robot.respond /karma (\S+[^-\s])$/i, (msg) ->
+  robot.respond /karma (\S+[^-\s])\s*$/i, (msg) ->
     match = msg.match[1].toLowerCase()
     if match != "best" && match != "worst"
       msg.send "\"#{match}\" has #{karma.get(match)} karma."

--- a/scripts/pun.coffee
+++ b/scripts/pun.coffee
@@ -78,6 +78,7 @@ module.exports = (robot) ->
       "If your books keep falling on the floor, don't make excuses. You only have your shelf to blame.",
       "Never play golf without a spare pair of pants. It will definitely come in handy if you get a hole in one.",
       "Using a keyboard with a home sound system would be stereotyping.",
+      "When the cheese factory exploded, it was an awful mess to clean up. The brie was everywhere!",
       # Add new puns above here. Don't forget your trailing comma
       "/em fails to pun."
     ]


### PR DESCRIPTION
In particular this should correct a common issue in HipChat where attempting to type something like
> nerdbot karma @JustinMullin

results in no response, as HipChat "helpfully" appends a space at the end of the line after auto-completing the mention, and the command fails to match.