### PR TITLE
Replaced hubot-scripts hosted MTG card fetcher

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -10,7 +10,6 @@
   "fuck_yeah_nouns.coffee",
   "google.coffee",
   "howdoi.coffee",
-  "mtg.coffee",
   "news.coffee",
   "nice.coffee",
   "polite.coffee",

--- a/scripts/pun.coffee
+++ b/scripts/pun.coffee
@@ -80,6 +80,7 @@ module.exports = (robot) ->
       "Using a keyboard with a home sound system would be stereotyping.",
       "When the cheese factory exploded, it was an awful mess to clean up. The brie was everywhere!",
       "I think my printer must be a jazz musician, it's always jamming.",
+      "I tried really hard to make my banking career work out, but I just kept losing interest.",
       # Add new puns above here. Don't forget your trailing comma
       "/em fails to pun."
     ]

--- a/scripts/sadrobot.coffee
+++ b/scripts/sadrobot.coffee
@@ -1,0 +1,32 @@
+# Description:
+#   Routes MTG card names and search terms to a locally-hosted MTG card fetcher service.
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   Note: this behavior is allowed only from within the Magic room.
+#
+#   Query by name with double square brackets: [[Counterspell]]
+#   Query by search terms with double curly braces: {{o:"counter target spell"}}
+#
+# Author:
+#   jmullin
+
+module.exports = (robot) ->
+  baseUrl = "http://sadrobot.nerderylabs.com"
+
+  robot.hear /\[\[([^\]]+)\]\]/g, (msg) ->
+    if msg.message.room is "Magic"
+      for match in msg.match
+        robot.http("#{baseUrl}/byName")
+          .post(match.substring(2, match.length - 2)) (err, res, body) ->
+
+  robot.hear /\{\{([^\}]+)\}\}/g, (msg) ->
+    if msg.message.room is "Magic"
+      for match in msg.match
+        robot.http("#{baseUrl}/byQuery")
+          .post(match.substring(2, match.length - 2)) (err, res, body) ->


### PR DESCRIPTION
It's been supplanted with a passthrough to a locally hosted, new-n-improved fetcher service. That service and this hubot script only operate on the Magic channel to avoid adding irrelevant noise to communities not so interested in Magic cards.